### PR TITLE
feat: 支持使用自定义的按钮id

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,9 +7,13 @@ app:
   test-url: http://www.baidu.com # 用于被校园网重定向到登录页面，请不要设置为能够在不登录的情况下还能解析的域名。
   timeout: 60s # 每次尝试登录的超时时间。
   retry: 3 # 最小有效值为 1。
+button:
+  login-id: login-account # 登录页面HTML中的登录按钮标签id
+  logout-id: btn-logout # 登录页面HTML中的退出按钮标签id
 cdp:
   flags: # 设置参考 https://pkg.go.dev/github.com/chromedp/chromedp。
     headless: true # 设置为 true 则不打开浏览器窗口。
     hide-scrollbars: true
     mute-audio: true
     no-default-browser-check: true # 可能需要设置 headless 为 true 才有效，如果打开窗口运行，可能会在桌面添加图标。
+    no-first-login: true # 设置为true，浏览器则不会弹出首次登录页面。

--- a/internal/srunlogin/command/login.go
+++ b/internal/srunlogin/command/login.go
@@ -51,6 +51,8 @@ func getSolution(solution string) (solution.Solution, error) {
 	username := viper.GetString("account.username")
 	password := viper.GetString("account.password")
 	isp := viper.GetString("account.isp")
+	buttonLoginID := viper.GetString("button.login-id")
+	buttonLogoutID := viper.GetString("button.logout-id")
 
 	switch solution {
 	case "cdp":
@@ -67,6 +69,9 @@ func getSolution(solution string) (solution.Solution, error) {
 			Password: password,
 			Timeout:  timeout,
 			Flags:    cdpFlags,
+
+			ButtonLoginID:  buttonLoginID,
+			ButtonLogoutID: buttonLogoutID,
 		}), nil
 	default:
 		return nil, errSolutionUndefined

--- a/internal/srunlogin/solution/cdp/cdp.go
+++ b/internal/srunlogin/solution/cdp/cdp.go
@@ -17,6 +17,9 @@ type Options struct {
 	Password string
 	Timeout  time.Duration
 	Flags    map[string]interface{}
+
+	ButtonLoginID  string
+	ButtonLogoutID string
 }
 
 // Solution using Chrome DP
@@ -74,7 +77,7 @@ func (sln *Solution) getTasks() chromedp.Tasks {
 		inputTask("username", sln.opts.Username),
 		inputTask("password", sln.opts.Password),
 		selectISPTask(sln.opts.ISP),
-		loginTask(),
+		loginTask(sln.opts.ButtonLoginID, sln.opts.ButtonLogoutID),
 	}
 }
 
@@ -95,10 +98,12 @@ func selectISPTask(isp string) chromedp.Tasks {
 	}
 }
 
-func loginTask() chromedp.Tasks {
+func loginTask(buttonLoginID, buttonLogoutID string) chromedp.Tasks {
+	loginSel := fmt.Sprintf(`//button[@id="%s"]`, buttonLoginID)
+	logoutSel := fmt.Sprintf(`//button[@id="%s"]`, buttonLogoutID)
 	return chromedp.Tasks{
-		chromedp.WaitVisible(`//button[@id="login"]`, chromedp.BySearch),
-		chromedp.Click(`//button[@id="login"]`, chromedp.BySearch),
-		chromedp.WaitVisible(`//button[@id="logout"]`, chromedp.BySearch),
+		chromedp.WaitVisible(loginSel, chromedp.BySearch),
+		chromedp.Click(loginSel, chromedp.BySearch),
+		chromedp.WaitVisible(logoutSel, chromedp.BySearch),
 	}
 }


### PR DESCRIPTION
 1. 由于校园网登录页面html更新，需要支持使用自定义的按钮id。（现在校园网的新页面对应的登录按钮和注销按钮id都变了）
 2. 使用cmp时，打开浏览器会弹出自动登录导致脚本无法正常使用。新增默认配置，chrome 打开时不进行登录